### PR TITLE
Prepare for 1.1.0 release

### DIFF
--- a/difference/src/commonMain/kotlin/dev/andrewbailey/diff/DiffOperation.kt
+++ b/difference/src/commonMain/kotlin/dev/andrewbailey/diff/DiffOperation.kt
@@ -1,32 +1,136 @@
 package dev.andrewbailey.diff
 
+/**
+ * An individual operation contained in a [DiffResult] between two collections.
+ */
 sealed class DiffOperation<T> {
 
+    /**
+     * An operation in a diff to indicate the removal of an object between the before and after
+     * states of the collections.
+     *
+     * @param index The index of the removal, expressed as the index to remove from the collection
+     * if you had applied all previous operations in this diff.
+     * @param item The item that was removed from the original collection
+     */
     data class Remove<T>(
         val index: Int,
         val item: T
     ) : DiffOperation<T>()
 
+    /**
+     * An operation in a diff to indicate the removal of a range of objects between the before and
+     * after states of the collections.
+     *
+     * @param startIndex The start index of the removal (inclusive), expressed as the index to
+     * remove from the collection if you had applied all previous operations in this diff.
+     * @param endIndex The end index of the removal (exclusive), expressed as the index to remove
+     * from the collection if you had applied all previous operations in this diff.
+     */
     data class RemoveRange<T>(
         val startIndex: Int,
         val endIndex: Int
     ) : DiffOperation<T>()
 
+    /**
+     * An operation in a diff to indicate the insertion of an object between the before and after
+     * states of the collections.
+     *
+     * @param index The index of the insertion, expressed as the index to add the given object to
+     * the collection if you had applied all previous operations in this diff.
+     * @param item The object to insert at the specified location.
+     */
     data class Add<T>(
         val index: Int,
         val item: T
     ) : DiffOperation<T>()
 
+    /**
+     * An operation in a diff to indicate the insertion of several objects between the before and
+     * after states of the collections.
+     *
+     * @param index The index of the insertions, expressed as the index to add the given object to
+     * the collection if you had applied all previous operations in this diff. The first object in
+     * the given items list should be inserted at this index, with all subsequent operations
+     * following consecutively.
+     * @param items The objects to insert at the specified location. Always contains at least two
+     * values.
+     */
     data class AddAll<T>(
         val index: Int,
         val items: List<T>
     ) : DiffOperation<T>()
 
+    /**
+     * An operation in a diff to indicate the movement of one object to a new index between the
+     * before and after states of the collections. Only included in a diff if movement detection
+     * was enabled.
+     *
+     * The indices expressed in this object assume applying the move operation as an atomic
+     * operation to a collection that has had all other operations in this diff applied. To
+     * implement as a remove-then-add call, correct the [toIndex] as shown:
+     *
+     * ```kotlin
+     * add(removeAt(fromIndex), if (toIndex < fromIndex) toIndex else toIndex - 1)
+     * ```
+     *
+     * @param fromIndex The index of the object as it would appear if you had applied all previous
+     * operations in this diff.
+     * @param toIndex The new index that this object should appear at, not accounting for the
+     * deletion of this object from its current location.
+     */
     data class Move<T>(
         val fromIndex: Int,
         val toIndex: Int
     ) : DiffOperation<T>()
 
+    /**
+     * An operation in a diff to indicate the movement of a range of objects to a new location
+     * between the before and after states of the collections. Only included in a diff if movement
+     * detection was enabled.
+     *
+     * The indices expressed in this object assume applying the move operation as an atomic
+     * operation to a collection that has had all other operations in this diff applied. To
+     * implement as a removeRange-then-add call, correct the [toIndex] as shown:
+     *
+     * ```kotlin
+     * addAll(
+     *     values = removeRange(fromIndex, itemCount),
+     *     index = if (toIndex < fromIndex) toIndex else toIndex - 1
+     * )
+     * ```
+     *
+     * Alternatively, to implement as a loop of remove-then-add calls, correct the destination
+     * indices as shown:
+     *
+     * ```kotlin
+     *  when {
+     *      toIndex < fromIndex -> {
+     *          (0 until count).forEach { item ->
+     *              val oldIndex = fromIndex + item
+     *              val newIndex = toIndex + item
+     *              add(
+     *                  item = removeAt(oldIndex),
+     *                  index = if (newIndex < oldIndex) newIndex else newIndex - 1
+     *              )
+     *          }
+     *      }
+     *      toIndex > fromIndex -> {
+     *          repeat(count) {
+     *              add(
+     *                  item = removeAt(fromIndex),
+     *                  index = newIndex
+     *              )
+     *          }
+     *      }
+     *  }
+     * ```
+     *
+     * @param fromIndex The index of the object as it would appear if you had applied all previous
+     * operations in this diff.
+     * @param toIndex The new index that this object should appear at, not accounting for the
+     * deletion of this object from its current location.
+     */
     data class MoveRange<T>(
         val fromIndex: Int,
         val toIndex: Int,

--- a/difference/src/commonMain/kotlin/dev/andrewbailey/diff/DiffResult.kt
+++ b/difference/src/commonMain/kotlin/dev/andrewbailey/diff/DiffResult.kt
@@ -1,7 +1,42 @@
 package dev.andrewbailey.diff
 
-class DiffResult<T> internal constructor(val operations: List<DiffOperation<T>>) {
+/**
+ * Stores the result of a diff calculated by [differenceOf].
+ */
+class DiffResult<T> internal constructor(
+    /**
+     * The sequence of operations in the diff. When applied in order, these operations will
+     * transform the original collection into the target collection. This list always coalesces
+     * ranges of the same operation together, and prefers to use the minimum number of
+     * [DiffOperation] objects required to express the diff.
+     */
+    val operations: List<DiffOperation<T>>
+) {
 
+    /**
+     * Executes the operations in this diff-in order. This function is generally intended to
+     * mirror the state changes expressed in this difference to a parallel data structure derived
+     * by the diff-ed collection.
+     *
+     * The lambdas passed into this method are invoked to respond to each operation. When an index
+     * is specified, it expresses the index of the in-flight data structure. That is, an index
+     * which is only valid when all previously dispatched operations have been applied to the
+     * original collection.
+     *
+     * This overload applies operations on an element-by-element basis. Use the overload with
+     * the additional "Range" lambdas to support bulk operations, which can improve performance.
+     *
+     * @param remove Called to remove the object at the specified `index` from the in-flight
+     * collection as a step towards the final collection.
+     * @param insert Called to insert the given `item` at the specified `index` to the in-flight
+     * collection as a step towards the final collection.
+     * @param move If this diff was generated with moves detected, this function is called to move
+     * the item at `oldIndex` to `newIndex`. If this diff was not generated with moves detected,
+     * this lambda will never be invoked. These indexes are written assuming an atomic operation
+     * to perform the move. To implement a move operation as a remove and re-insert operation, the
+     * `newIndex` may need to be corrected with an offset. In practice, this looks like
+     * `add(removeAt(oldIndex), if (newIndex < oldIndex) else newIndex - 1)`.
+     */
     inline fun applyDiff(
         crossinline remove: (index: Int) -> Unit,
         crossinline insert: (item: T, index: Int) -> Unit,
@@ -38,6 +73,40 @@ class DiffResult<T> internal constructor(val operations: List<DiffOperation<T>>)
         )
     }
 
+    /**
+     * Executes the operations in this diff-in order, with support for applying operations in bulk
+     * when a large span of items experience the same transformation. This function is generally
+     * intended to mirror the state changes expressed in this difference to a parallel data
+     * structure derived by the diff-ed collection.
+     *
+     * The lambdas passed into this method are invoked to respond to each aggregated operation.
+     * When an index or range is specified, it is indexed to the in-flight data structure. That is,
+     * an index which is only valid when all previously dispatched operations have been applied
+     * to the original collection.
+     *
+     * @param remove Called to remove the object at the specified `index` from the in-flight
+     * collection as a step towards the final collection.
+     * @param removeRange Called to remove all objects between index `start` (inclusive) and `end`
+     * (exclusive) from the in-flight collection as a step towards the final collection.
+     * @param insert Called to insert the given `item` at the specified `index` to the in-flight
+     * collection as a step towards the final collection.
+     * @param insertAll Called to insert all items in the provided collection to the in-flight
+     * collection. The given list of items should be added in-order with the inserted sequence
+     * starting at the provided `index` in the in-flight collection.
+     * @param move If this diff was generated with moves detected, this function is called to move
+     * the item at `oldIndex` to `newIndex`. If this diff was not generated with moves detected,
+     * this lambda will never be invoked. These indexes are written assuming an atomic operation
+     * to perform the move. To implement a move operation as a remove and re-insert operation, the
+     * `newIndex` may need to be corrected with an offset. In practice, this looks like
+     * `add(removeAt(oldIndex), if (newIndex < oldIndex) newIndex else newIndex - 1)`.
+     * @param moveRange This lambda is used in the same way as [move] is, but operates on a
+     * contiguous span of two or more items to be moved. The indexing works in the same way as it
+     * does for the single-item variant, in that the `newIndex` and `oldIndex` arguments provided
+     * are both specified with respect to the current state of the in-flight array. If implementing
+     * this expression as an addRange and removeRange operation, or by breaking this operation into
+     * multiple move operations, you will need to correct the destination index when it is before
+     * the source index.
+     */
     inline fun applyDiff(
         crossinline remove: (index: Int) -> Unit,
         crossinline removeRange: (start: Int, end: Int) -> Unit,

--- a/difference/src/commonMain/kotlin/dev/andrewbailey/diff/Difference.kt
+++ b/difference/src/commonMain/kotlin/dev/andrewbailey/diff/Difference.kt
@@ -4,6 +4,33 @@ package dev.andrewbailey.diff
 
 import kotlin.jvm.JvmName
 
+/**
+ * Constructs a diff between the [original] and [updated] list inputs. The returned [DiffResult]
+ * represents a sequence of operations which, if applied in order on the [original] list will
+ * yield the [updated] list. The returned list always contains the minimum number of operations
+ * required to transform the original input to the updated input.
+ *
+ * Optionally, move operations can be enabled or disabled by specifying [detectMoves]. If disabled,
+ * the diff result will only include add and delete operations, which may cause the same item to
+ * be deleted and re-inserted. If movement detection is enabled, all objects shared between the
+ * two lists will either remain in place or be moved within the list instead of removing and
+ * reinserting them.
+ *
+ * Internally, this function performs the Eugene-Myers diffing algorithm. the worst case runtime
+ * of the algorithm takes on the order of O((M+N)×D + D log D) operations. M and N are the lengths
+ * of the two input lists, and D is the smallest number of operations that it takes to modify the
+ * original list into the updated one. If move detection is enabled, add another O(D²) to that
+ * runtime.
+ *
+ * @param original The "before" state of the list to be diffed. For optimal performance, it is
+ * critical that this data structure supports efficient random reads.
+ * @param updated The "after" state of the list to be diffed. For optimal performance, it is
+ * critical that this data structure supports efficient random reads.
+ * @param detectMoves Whether or not to detect moved objects as such. When disabled, the returned
+ * diff will only contain insert and delete operations. Enabled by default.
+ * @return A [DiffResult] containing a shortest possible sequence of operations that can transform
+ * the "before" state of the list into the "after" state of the list.
+ */
 fun <T> differenceOf(
     original: List<T>,
     updated: List<T>,

--- a/difference/src/commonMain/kotlin/dev/andrewbailey/diff/impl/CircularIntArray.kt
+++ b/difference/src/commonMain/kotlin/dev/andrewbailey/diff/impl/CircularIntArray.kt
@@ -3,17 +3,17 @@ package dev.andrewbailey.diff.impl
 import kotlin.jvm.JvmInline
 
 @JvmInline
-internal value class CircularIntArray(private val array: IntArray) {
+internal value class CircularIntArray(val array: IntArray) {
 
     constructor(size: Int) : this(IntArray(size))
 
-    operator fun get(index: Int): Int = array[toInternalIndex(index)]
+    inline operator fun get(index: Int): Int = array[toLinearIndex(index)]
 
-    operator fun set(index: Int, value: Int) {
-        array[toInternalIndex(index)] = value
+    inline operator fun set(index: Int, value: Int) {
+        array[toLinearIndex(index)] = value
     }
 
-    private fun toInternalIndex(index: Int): Int {
+    private inline fun toLinearIndex(index: Int): Int {
         val moddedIndex = index % array.size
         return if (moddedIndex < 0) {
             moddedIndex + array.size

--- a/difference/src/commonMain/kotlin/dev/andrewbailey/diff/impl/Extensions.kt
+++ b/difference/src/commonMain/kotlin/dev/andrewbailey/diff/impl/Extensions.kt
@@ -2,17 +2,26 @@ package dev.andrewbailey.diff.impl
 
 import kotlin.math.abs
 
-internal fun Int.isEven() = abs(this) % 2 == 0
+internal inline fun Int.isEven() = abs(this) % 2 == 0
 
-internal fun Int.isOdd() = abs(this) % 2 == 1
+internal inline fun Int.isOdd() = abs(this) % 2 == 1
 
-internal fun <T> MutableList<T>.push(item: T) {
+internal inline fun <T> MutableList<T>.push(item: T) {
     add(item)
 }
 
-internal fun <T> MutableList<T>.pop(): T {
-    check(isNotEmpty()) {
-        "List has no items"
+internal inline fun <T> MutableList<T>.pop(): T = removeAt(size - 1)
+
+internal inline fun <T> List<T>.fastForEach(action: (T) -> Unit) {
+    @Suppress("ReplaceManualRangeWithIndicesCalls")
+    for (i in 0 until size) {
+        action(this[i])
     }
-    return removeAt(size - 1)
+}
+
+internal inline fun <T> List<T>.fastForEachIndexed(action: (Int, T) -> Unit) {
+    @Suppress("ReplaceManualRangeWithIndicesCalls")
+    for (i in 0 until size) {
+        action(i, this[i])
+    }
 }

--- a/difference/src/commonMain/kotlin/dev/andrewbailey/diff/impl/Point.kt
+++ b/difference/src/commonMain/kotlin/dev/andrewbailey/diff/impl/Point.kt
@@ -1,6 +1,16 @@
 package dev.andrewbailey.diff.impl
 
-internal data class Point(
-    val x: Int,
-    val y: Int
-)
+import kotlin.jvm.JvmInline
+
+@JvmInline
+internal value class Point(private val packed: Long) {
+    val x: Int get() = (packed and 0xFFFFFFFF).toInt()
+    val y: Int get() = (packed shr 32).toInt()
+
+    constructor(x: Int, y: Int) : this(
+        (x.toLong() and 0xFFFFFFFF) or (y.toLong() shl 32)
+    )
+
+    inline operator fun component1() = x
+    inline operator fun component2() = y
+}

--- a/difference/src/commonMain/kotlin/dev/andrewbailey/diff/impl/Snake.kt
+++ b/difference/src/commonMain/kotlin/dev/andrewbailey/diff/impl/Snake.kt
@@ -3,4 +3,10 @@ package dev.andrewbailey.diff.impl
 internal data class Snake(
     val start: Point,
     val end: Point
-)
+) : Comparable<Snake> {
+    override fun compareTo(other: Snake): Int = if (start.x == other.start.x) {
+        start.y - other.start.y
+    } else {
+        start.x - other.start.x
+    }
+}

--- a/difference/src/commonTest/kotlin/dev/andrewbailey/diff/impl/MyersDiffAlgorithmTest.kt
+++ b/difference/src/commonTest/kotlin/dev/andrewbailey/diff/impl/MyersDiffAlgorithmTest.kt
@@ -131,7 +131,7 @@ class MyersDiffAlgorithmTest {
         )
     }
 
-    private fun <T> applyDiff(original: List<T>, diff: Sequence<MyersDiffOperation<T>>): List<T> =
+    private fun <T> applyDiff(original: List<T>, diff: List<MyersDiffOperation<T>>): List<T> =
         original.toMutableList().apply {
             var index = 0
             diff.forEach { operation ->

--- a/difference/src/jvmMain/kotlin/dev/andrewbailey/diff/DiffReceiver.kt
+++ b/difference/src/jvmMain/kotlin/dev/andrewbailey/diff/DiffReceiver.kt
@@ -6,6 +6,8 @@ import dev.andrewbailey.diff.DiffOperation.Move
 import dev.andrewbailey.diff.DiffOperation.MoveRange
 import dev.andrewbailey.diff.DiffOperation.Remove
 import dev.andrewbailey.diff.DiffOperation.RemoveRange
+import dev.andrewbailey.diff.impl.fastForEach
+import dev.andrewbailey.diff.impl.fastForEachIndexed
 
 /**
  * This class serves as a convenience class for Java users who may find it tedious to call
@@ -18,7 +20,7 @@ import dev.andrewbailey.diff.DiffOperation.RemoveRange
 abstract class DiffReceiver<T> {
 
     fun applyDiff(diff: DiffResult<T>) {
-        diff.operations.forEach { operation ->
+        diff.operations.fastForEach { operation ->
             when (operation) {
                 is Remove -> {
                     remove(operation.index)
@@ -53,7 +55,7 @@ abstract class DiffReceiver<T> {
     abstract fun insert(item: T, index: Int)
 
     open fun insertAll(items: List<T>, index: Int) {
-        items.forEachIndexed { itemIndex, item ->
+        items.fastForEachIndexed { itemIndex, item ->
             insert(item, index + itemIndex)
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 android.enableAdditionalTestOutput=true
 
 GROUP=dev.andrewbailey.difference
-VERSION_NAME=1.0.0
+VERSION_NAME=1.1.0
 
 POM_ARTIFACT_ID=difference
 POM_NAME=Difference


### PR DESCRIPTION
This PR contains all code changes to be included with Difference version 1.1.0. In addition to bumping the version number, this PR includes the following changes:
 - Added KDocs to all public APIs
 - Reduced the number of memory allocations needed to create a diff by making `Point` a value class, and reducing the number of unnecessary list copies created. Quick testing has shown that computing a difference now uses approximately 60-65% fewer allocations. The end result is that the algorithm now runs between 8-17% faster, with smaller diffs seeing more gains than larger diffs. Similarly, diffs that do not detect moves see a higher percentage improvement than if move detection is enabled.