### PR TITLE
Add iosSimulatorArm64 as a target

### DIFF
--- a/difference/build.gradle
+++ b/difference/build.gradle
@@ -24,6 +24,11 @@ kotlin {
             artifactId = 'difference-ios-arm64'
         }
     }
+    iosSimulatorArm64 {
+        mavenPublication {
+            artifactId = 'difference-ios-simulator-arm64'
+        }
+    }
     linuxX64 {
         mavenPublication {
             artifactId = 'difference-linux-x64'


### PR DESCRIPTION
Adds iosSimulatorArm64 as a target which is useful for testing iOS versions locally